### PR TITLE
Show how multiple enforcers interact

### DIFF
--- a/Setup/PgDatabaseFixture.cs
+++ b/Setup/PgDatabaseFixture.cs
@@ -49,6 +49,11 @@ public class PgDatabaseFixture : IAsyncInitializer, IAsyncDisposable
             Factory = new PooledDbContextFactory<Database>(
                 new DbContextOptionsBuilder<Database>()
                     .UseNpgsql(_pg.GetConnectionString())
+                    .LogTo(
+                        Console.WriteLine,
+                        Microsoft.Extensions.Logging.LogLevel.Information
+                    )
+                    .EnableSensitiveDataLogging()
                     .Options
             );
 
@@ -65,6 +70,11 @@ public class PgDatabaseFixture : IAsyncInitializer, IAsyncDisposable
             CasbinFactory = new PooledDbContextFactory<CasbinDatabase>(
                 new DbContextOptionsBuilder<CasbinDatabase>()
                     .UseNpgsql(_pgCasbin.GetConnectionString())
+                    .LogTo(
+                        Console.WriteLine,
+                        Microsoft.Extensions.Logging.LogLevel.Information
+                    )
+                    .EnableSensitiveDataLogging()
                     .Options
             );
 

--- a/Tests/CasbinBasicTests.cs
+++ b/Tests/CasbinBasicTests.cs
@@ -86,7 +86,7 @@ public class CasbinBasicTests
         Console.WriteLine("Adding write policy to 'default'");
         _enforcer.AddPolicy(_aliceId, _aliceId, "write", "Motion");
 
-        Console.WriteLine("Enforce");
+        Console.WriteLine("Enforce on default");
         // Check if alice can read her own record
         var canRead = await _enforcer.EnforceAsync(
             _aliceId,
@@ -96,6 +96,7 @@ public class CasbinBasicTests
         );
         await Assert.That(canRead).IsTrue();
 
+        Console.WriteLine("Enforce on 2");
         var canRead2 = await enforcer2.EnforceAsync(
             _aliceId,
             _aliceId,


### PR DESCRIPTION
Shows that the enforcers actually load the policy when they are created and do not go to the db when checking the policy.

Here are the relevant logs for the `Multiple_Enforcers` test

```
Creating Enforcer: default
info: 2025-09-15 10:27:18.316 RelationalEventId.CommandExecuted[20101] (Microsoft.EntityFrameworkCore.Database.Command) 
      Executed DbCommand (4ms) [Parameters=[], CommandType='Text', CommandTimeout='30']
      SELECT c.id, c.ptype, c.v0, c.v1, c.v2, c.v3, c.v4, c.v5
      FROM casbin.casbin_rule AS c
Created Enforce: default
Adding Alice
info: 2025-09-15 10:27:18.381 RelationalEventId.CommandExecuted[20101] (Microsoft.EntityFrameworkCore.Database.Command) 
      Executed DbCommand (15ms) [Parameters=[@p0='Motion' (Nullable = false), @p1='alice@example.com' (Nullable = false), @p2='Alice' (Nullable = false)], CommandType='Text', CommandTimeout='30']
      INSERT INTO "Users" ("Company", "Email", "Name")
      VALUES (@p0, @p1, @p2)
      RETURNING "Id";
Adding Policy
info: 2025-09-15 10:27:18.441 RelationalEventId.CommandExecuted[20101] (Microsoft.EntityFrameworkCore.Database.Command) 
      Executed DbCommand (2ms) [Parameters=[@__policyType_0='p', @__field_1='1', @__field_2='1', @__field_3='read', @__field_4='Motion'], CommandType='Text', CommandTimeout='30']
      SELECT EXISTS (
          SELECT 1
          FROM casbin.casbin_rule AS c
          WHERE c.ptype = @__policyType_0 AND c.v0 = @__field_1 AND c.v1 = @__field_2 AND c.v2 = @__field_3 AND c.v3 = @__field_4)
info: 2025-09-15 10:27:18.455 RelationalEventId.CommandExecuted[20101] (Microsoft.EntityFrameworkCore.Database.Command) 
      Executed DbCommand (1ms) [Parameters=[@p0='01994dc5-e32b-7a5e-975e-09fdaff750fd', @p1='p', @p2='1', @p3='1', @p4='read', @p5='Motion', @p6=NULL, @p7=NULL], CommandType='Text', CommandTimeout='30']
      INSERT INTO casbin.casbin_rule (id, ptype, v0, v1, v2, v3, v4, v5)
      VALUES (@p0, @p1, @p2, @p3, @p4, @p5, @p6, @p7);
info: 2025-09-15 10:27:18.460 RelationalEventId.CommandExecuted[20101] (Microsoft.EntityFrameworkCore.Database.Command) 
      Executed DbCommand (0ms) [Parameters=[], CommandType='Text', CommandTimeout='30']
      SELECT c.id, c.ptype, c.v0, c.v1, c.v2, c.v3, c.v4, c.v5
      FROM casbin.casbin_rule AS c
info: 2025-09-15 10:27:18.464 RelationalEventId.CommandExecuted[20101] (Microsoft.EntityFrameworkCore.Database.Command) 
      Executed DbCommand (0ms) [Parameters=[@p0='01994dc5-e32b-7a5e-975e-09fdaff750fd'], CommandType='Text', CommandTimeout='30']
      DELETE FROM casbin.casbin_rule
      WHERE id = @p0;
info: 2025-09-15 10:27:18.470 RelationalEventId.CommandExecuted[20101] (Microsoft.EntityFrameworkCore.Database.Command) 
      Executed DbCommand (0ms) [Parameters=[@p0='01994dc5-e345-7ba6-b24a-ab1582c2c57e', @p1='p', @p2='1', @p3='1', @p4='read', @p5='Motion', @p6=NULL, @p7=NULL], CommandType='Text', CommandTimeout='30']
      INSERT INTO casbin.casbin_rule (id, ptype, v0, v1, v2, v3, v4, v5)
      VALUES (@p0, @p1, @p2, @p3, @p4, @p5, @p6, @p7);
Policy Saved
Creating Enforcer: 2
info: 2025-09-15 10:27:18.478 RelationalEventId.CommandExecuted[20101] (Microsoft.EntityFrameworkCore.Database.Command) 
      Executed DbCommand (0ms) [Parameters=[], CommandType='Text', CommandTimeout='30']
      SELECT c.id, c.ptype, c.v0, c.v1, c.v2, c.v3, c.v4, c.v5
      FROM casbin.casbin_rule AS c
Created Enforce: 2
Adding write policy to 'default'
info: 2025-09-15 10:27:18.481 RelationalEventId.CommandExecuted[20101] (Microsoft.EntityFrameworkCore.Database.Command) 
      Executed DbCommand (1ms) [Parameters=[@__policyType_0='p', @__field_1='1', @__field_2='1', @__field_3='write', @__field_4='Motion'], CommandType='Text', CommandTimeout='30']
      SELECT EXISTS (
          SELECT 1
          FROM casbin.casbin_rule AS c
          WHERE c.ptype = @__policyType_0 AND c.v0 = @__field_1 AND c.v1 = @__field_2 AND c.v2 = @__field_3 AND c.v3 = @__field_4)
info: 2025-09-15 10:27:18.483 RelationalEventId.CommandExecuted[20101] (Microsoft.EntityFrameworkCore.Database.Command) 
      Executed DbCommand (1ms) [Parameters=[@p0='01994dc5-e351-785e-8aab-fd21ed6c88e1', @p1='p', @p2='1', @p3='1', @p4='write', @p5='Motion', @p6=NULL, @p7=NULL], CommandType='Text', CommandTimeout='30']
      INSERT INTO casbin.casbin_rule (id, ptype, v0, v1, v2, v3, v4, v5)
      VALUES (@p0, @p1, @p2, @p3, @p4, @p5, @p6, @p7);
Enforce on default
Enforce on 2
```